### PR TITLE
fix call to `is_alive`

### DIFF
--- a/src/accapi/client.py
+++ b/src/accapi/client.py
@@ -48,7 +48,7 @@ class ThreadedSocketReader(object):
     def isAlive(self):
         if self._thread is None:
             return False
-        return self._thread.isAlive()
+        return self._thread.is_alive()
 
     @property
     def size(self):
@@ -402,7 +402,7 @@ class AccClient(object):
     def isAlive(self):
         if self._thread is None:
             return False
-        return self._thread.isAlive()
+        return self._thread.is_alive()
 
     def start(
         self,


### PR DESCRIPTION
Please let me know if there is a better PR process.

This addresses an issue in calling the `is_alive` for the thread. Previously it was `self._thread.isAlive()` however the actual method should be called in snake case, `is_alive()`.